### PR TITLE
Fix: detect new loading site

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,12 @@
     "128": "images/icon-128.png"
   },
   "background": {
-    "service_worker": "background.js"
-  }
+    "service_worker": "./scripts/background.js"
+  },
+  "content_scripts": [
+    {
+      "js": ["scripts/content.js"],
+      "matches": ["https://*/*", "http://*/*"]
+    }
+  ]
 }

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -18,15 +18,23 @@ chrome.storage.onChanged.addListener(({ isActive }) => {
   }
 });
 
+chrome.runtime.onMessage.addListener(async (request) => {
+  if (request.block) {
+    const blackList = await chrome.storage.sync.get().then((store) => store.blackList);
+    blockPages(blackList);
+  }
+});
+
 async function blocker() {
   const isActive = await chrome.storage.local.get().then((item) => item.isActive);
-  const blackList = await chrome.storage.sync.get().then((store) => {
-    if (!isEmpty(store.blackList)) {
-      return store.blackList;
-    }
-    return [];
-  });
+
   if (isActive) {
+    const blackList = await chrome.storage.sync.get().then((store) => {
+      if (!isEmpty(store.blackList)) {
+        return store.blackList;
+      }
+      return [];
+    });
     blockPages(blackList);
   }
 }

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -1,0 +1,19 @@
+(async () => {
+  const isActive = await chrome.storage.local.get().then((item) => item.isActive);
+  if (!isActive) return;
+  function isEmpty(obj) {
+    for (var x in obj) {
+      return false;
+    }
+    return true;
+  }
+  const blackList = await chrome.storage.sync.get().then((store) => {
+    if (!isEmpty(store.blackList)) {
+      return store.blackList;
+    }
+    return [];
+  });
+  if (blackList.length < 1) return;
+
+  chrome.runtime.sendMessage({ block: true });
+})();


### PR DESCRIPTION
It wasn't detecting new loading websites. So I find two ways to fix it. 
First is add `onUpdated` listener to tabs but it was triggered too often.
Second is add content script and send message to `background.js` every time when `isActive` true.